### PR TITLE
Revert "Update nextcloud Docker tag to v20.0.7"

### DIFF
--- a/cluster/media/nextcloud/helmrelease.yaml
+++ b/cluster/media/nextcloud/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
   values:
     image:
       repository: nextcloud
-      tag: 20.0.7
+      tag: 20.0.6
     ingress:
       enabled: true
       annotations:


### PR DESCRIPTION
Reverts lanquarden/roci-gitops#75

amd64 docker image not available yet, see https://github.com/nextcloud/docker/issues/1398